### PR TITLE
ci: run west update before building lightbulb sample

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -246,7 +246,7 @@ jobs:
             -v ${PWD}/mqtt-light-bulb:/workdir/nrf \
             -w /workdir/nrf/samples/net/mqtt-lightbulb \
             nordicplayground/nrfconnect-sdk:main \
-            west build \
+            west update && west build \
               -p always \
               -b thingy91_nrf9160_ns \
               --build-dir /workdir/project/build \


### PR DESCRIPTION
This ensures we use the right versions of the modules. Can be removed after we rebase to a specific release tag.